### PR TITLE
Feature/change root entry access

### DIFF
--- a/src/cdeLib/Entities/DirEntry.cs
+++ b/src/cdeLib/Entities/DirEntry.cs
@@ -362,20 +362,6 @@ public class DirEntry : ICommonEntry
         Size = size;
     }
 
-    [IgnoreMember]
-    public RootEntry TheRootEntry { get; set; }
-
-    public RootEntry GetRootEntry()
-    {
-        ICommonEntry entry = this;
-        while (entry.TheRootEntry == null)
-        {
-            entry = entry.ParentCommonEntry;
-        }
-
-        return entry.TheRootEntry;
-    }
-
     // ReSharper disable MemberCanBePrivate.Global
     [ProtoMember(3, IsRequired = false)]
     [FlatBufferItem(3)]

--- a/src/cdeLib/Entities/EntryHelper.cs
+++ b/src/cdeLib/Entities/EntryHelper.cs
@@ -60,11 +60,6 @@ public static class EntryHelper
 
             foreach (var dirEntry in rootEntry.Children)
             {
-                if (catalogRootEntry != null)
-                {
-                    rootEntry.TheRootEntry = catalogRootEntry;
-                }
-
                 funcContinue = traverseFunc(rootEntry, dirEntry);
                 if (!funcContinue)
                 {

--- a/src/cdeLib/Entities/ICommonEntry.cs
+++ b/src/cdeLib/Entities/ICommonEntry.cs
@@ -12,8 +12,6 @@ public interface ICommonEntry
 {
     bool IsDefaultSort { get; set; }
     int PathCompareWithDirTo(ICommonEntry de);
-    RootEntry TheRootEntry { get; set; }
-    RootEntry GetRootEntry();
 
     IList<DirEntry> Children { get; }
 

--- a/src/cdeLib/Entities/RootEntry.cs
+++ b/src/cdeLib/Entities/RootEntry.cs
@@ -787,11 +787,6 @@ public class RootEntry : object, ICommonEntry
 
             foreach (var dirEntry in commonEntry.Children)
             {
-                if (catalogRootEntry != null)
-                {
-                    commonEntry.TheRootEntry = catalogRootEntry;
-                }
-
                 funcContinue = traverseFunc(commonEntry, dirEntry);
                 if (!funcContinue)
                 {

--- a/src/cdeWin/CDEWinFormPresenter.cs
+++ b/src/cdeWin/CDEWinFormPresenter.cs
@@ -543,7 +543,7 @@ public class CDEWinFormPresenter : Presenter<ICDEWinForm>, ICDEWinFormPresenter
         _searchVals[(int)SearchResultColumn.FullPath] = pairDirEntry.ParentDE.FullPath;
 
         //TODO: Possibly wasting cycles traversing to the root for this, make smarter.
-        _searchVals[(int)SearchResultColumn.Catalog] = pairDirEntry.ParentDE.GetRootEntry().DefaultFileName;
+        _searchVals[(int)SearchResultColumn.Catalog] = pairDirEntry.GetRootEntry().DefaultFileName;
 
         searchHelper.RenderItem = BuildListViewItem(_searchVals, itemColor, pairDirEntry);
     }
@@ -756,8 +756,8 @@ public class CDEWinFormPresenter : Presenter<ICDEWinForm>, ICDEWinFormPresenter
 
             case 3:
                 compareResult = _config.MyCompareInfo.Compare(
-                    pde1.ParentDE.GetRootEntry().ActualFileName,
-                    pde2.ParentDE.GetRootEntry().ActualFileName,
+                    pde1.GetRootEntry().ActualFileName,
+                    pde2.GetRootEntry().ActualFileName,
                     _config.MyCompareOptions);
                 break;
 


### PR DESCRIPTION
The current RootEntry stuff in CommonEntry surprised me, I didn't remember it setup that way.
I had memories of PairDirEntry being the only that thing cared about root and being coupled to that.
In fact I had thoughts that users of PairDirEntry like the traverse function would have root entry known when they had a pde so they could provide it trivial to the traverse.
I think this change improves this.
