### PR TITLE
fix(Launch): Catch error if ExplorerAlt is undefined or can't be launched

### DIFF
--- a/src/cdeWin/appsettings.json
+++ b/src/cdeWin/appsettings.json
@@ -1,5 +1,6 @@
 ﻿{
   "ExplorerAlt": {
-    "Path": "c:\\Program Files\\Totalcmd\\totalcmd64.exe"
+    "Path": "c:\\Program Files\\Totalcmd\\totalcmd64.exe",
+    "Arguments": "/O /T /R={path}"
   }
 }


### PR DESCRIPTION
Show Message if ExplorerAlt cannot be launched. Provide message to user on how to fix.
Resolves #12