### PR TITLE
Fix/cdescan 24

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -13,20 +13,20 @@ CDE is a high-performance file system cataloging utility written in C# that crea
 ### Main Projects
 
 - **cde** - Command-line interface (CLI) application
-  - Target: .NET 9.0
+  - Target: .NET 10
   - Cross-platform: win-x64, linux-x64, osx-x64
   - Entry point for scan, find, hash, dupes, dump commands
   - Dependencies: Autofac, MediatR, CommandLineParser, Spectre.Console
 
 - **cdeLib** - Core library containing business logic
-  - Target: .NET 9.0
+  - Target: .NET 10
   - Contains all catalog operations, hashing, duplicate detection
   - Uses CQRS pattern with MediatR
-  - Serialization: Protobuf-net, MessagePack, FlatSharp
+  - Serialization: MessagePack, FlatSharp
   - Key dependencies: Autofac, MediatR, Serilog
 
 - **cdeWin** - Windows Forms GUI application
-  - Target: .NET 9.0 (Windows)
+  - Target: .NET 10 (Windows)
   - Browse, search, and navigate catalogs visually
   - Configuration stored in Local AppData or current directory
 
@@ -70,9 +70,8 @@ CDE is a high-performance file system cataloging utility written in C# that crea
 ### Serialization
 
 Multiple serialization formats supported:
-- **Protobuf-net** - Primary catalog file format (.cde files)
-- **MessagePack** - Alternative serialization
-- **FlatSharp** - FlatBuffers support
+- **MessagePack** - Primary catalog file format (.cde files)
+- **FlatSharp** - FlatBuffers support (alternative)
 
 ### Hashing
 
@@ -158,7 +157,7 @@ Located in `cdeLib/Infrastructure/`:
 - **Loading**: All .cde files in current directory or one level down are loaded
 - **Content**: Directory tree with optional MD5 hashes
 - **Size**: Highly efficient - 500MB for 11 billion entries
-- **Format**: Protobuf binary serialization (not compressed)
+- **Format**: MessagePack binary serialization (not compressed)
 
 ## Common Operations
 
@@ -270,7 +269,7 @@ Standard .NET test runners (tests use NUnit, xUnit)
 
 - **Autofac** - Dependency injection
 - **MediatR** - Command/query pattern
-- **Protobuf-net** - Primary serialization
+- **MessagePack** - Primary serialization
 - **Serilog** - Structured logging
 - **CommandLineParser** - CLI argument parsing
 - **Spectre.Console** - Rich console output

--- a/src/cde/CommandLine/CommandLineOptions.cs
+++ b/src/cde/CommandLine/CommandLineOptions.cs
@@ -8,7 +8,7 @@ namespace cde.CommandLine;
 [Verb("scan", HelpText = "Scans path and creates a cache file.")]
 public class ScanOptions
 {
-    [Value(0, HelpText = "Path to scan")]
+    [Value(0, Required = true, HelpText = "Path to scan")]
     public string Path { get; [UsedImplicitly] set; }
 
     [Option("desc", HelpText = "Description to set")]

--- a/src/cde/appsettings.json
+++ b/src/cde/appsettings.json
@@ -11,8 +11,7 @@
   },
   "Serilog": {
     "Using": [
-      "Serilog.Sinks.Console",
-      "Serilog.Sinks.Seq"
+      "Serilog.Sinks.Console"
     ],
     "MinimumLevel": "Debug",
     "WriteTo": [


### PR DESCRIPTION
Command-Line Interface Improvement:

* Made the `Path` argument in the `ScanOptions` class a required parameter, improving CLI usability and validation.

Logging Configuration:

* Removed the Seq sink from the Serilog configuration in `appsettings.json`, leaving only console logging.