### PR TITLE
fix (cde/startup): Warn user when appsettings.json is missing. Fixes #5

### DIFF
--- a/src/cde/AppContainerBuilder.cs
+++ b/src/cde/AppContainerBuilder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Autofac;
 using AutofacSerilogIntegration;
@@ -17,34 +16,39 @@ namespace cde;
 /// </summary>
 public static class AppContainerBuilder
 {
+    /// <summary>
+    /// Build the DI container. Returns null if appsettings.json is missing.
+    /// </summary>
     public static IContainer BuildContainer(string[] args)
     {
+        ConfigureBootstrapLogger();
+
+        // Check for appsettings.json before attempting to build
+        if (!ConfigBuilder.AppSettingsExists())
+        {
+            var currentDir = Directory.GetCurrentDirectory();
+            Log.Logger.Warning(
+                "Configuration file '{FileName}' not found in '{Directory}'",
+                ConfigBuilder.AppSettingsFileName, currentDir);
+            Log.Logger.Warning(
+                "Please ensure appsettings.json is in the same directory as the executable");
+            return null;
+        }
+
         var builder = new ContainerBuilder();
+        var config = new ConfigBuilder().Build(args);
+        ConfigureLogger(config);
+        builder.RegisterInstance(config);
+        builder.RegisterType<cdeLib.Infrastructure.Logger>().As<cdeLib.Infrastructure.ILogger>();
+        builder.RegisterLogger();
 
-        try
-        {
-            ConfigureBootstrapLogger();
-            var config = new ConfigBuilder().Build(args);
-            ConfigureLogger(config);
-            builder.RegisterInstance(config);
-            builder.RegisterType<cdeLib.Infrastructure.Logger>().As<cdeLib.Infrastructure.ILogger>();
-            builder.RegisterLogger();
-
-            builder.RegisterModule<CdelibModule>();
-            var configuration = MediatRConfigurationBuilder
-                .Create(typeof(AppContainerBuilder).Assembly)
-                .WithAllOpenGenericHandlerTypesRegistered()
-                .Build();
-            builder.RegisterMediatR(configuration);
-            return builder.Build();
-        }
-        catch (FileNotFoundException e)
-        {
-            // We'll assume it's the missing appsettings.json file error.
-            Log.Logger.Error(e,
-                "Please ensure there is an appsettings.json file in the same directory as the executable");
-            throw;
-        }
+        builder.RegisterModule<CdelibModule>();
+        var configuration = MediatRConfigurationBuilder
+            .Create(typeof(AppContainerBuilder).Assembly)
+            .WithAllOpenGenericHandlerTypesRegistered()
+            .Build();
+        builder.RegisterMediatR(configuration);
+        return builder.Build();
     }
 
     private static void ConfigureBootstrapLogger()

--- a/src/cde/Config/ConfigBuilder.cs
+++ b/src/cde/Config/ConfigBuilder.cs
@@ -5,11 +5,19 @@ namespace cde.Config;
 
 public class ConfigBuilder
 {
+    public const string AppSettingsFileName = "appsettings.json";
+
+    public static bool AppSettingsExists()
+    {
+        var path = Path.Combine(Directory.GetCurrentDirectory(), AppSettingsFileName);
+        return File.Exists(path);
+    }
+
     public IConfigurationRoot Build(string[] args)
     {
         return new ConfigurationBuilder()
             .SetBasePath(Directory.GetCurrentDirectory())   // required for single file application or it goes hunting in temp folder when it extracts.
-            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile(AppSettingsFileName, optional: true, reloadOnChange: true)
             .AddCommandLine(args)
             .Build();
     }

--- a/src/cde/Program.cs
+++ b/src/cde/Program.cs
@@ -27,10 +27,18 @@ public static class Program
 
     private static IMediator Mediatr { get; set; }
 
-    public static void InitProgram(string[] args)
+    /// <summary>
+    /// Initialize the program. Returns false if initialization failed (e.g., missing config).
+    /// </summary>
+    public static bool InitProgram(string[] args)
     {
         _container = AppContainerBuilder.BuildContainer(args);
+        if (_container == null)
+        {
+            return false;
+        }
         Mediatr = Resolve<IMediator>();
+        return true;
     }
 
     private static ParserResult<object> GetParserResult(IEnumerable<string> args)
@@ -56,7 +64,10 @@ public static class Program
 
     private static int Main(string[] args)
     {
-        InitProgram(args);
+        if (!InitProgram(args))
+        {
+            return 1; // Exit with error code if initialization failed
+        }
         Console.CancelKeyPress += BreakConsole;
         try
         {


### PR DESCRIPTION
This pull request improves the application's startup process by introducing a more robust check for the presence of the `appsettings.json` configuration file. The initialization now gracefully handles missing configuration by warning the user and exiting cleanly, rather than throwing an exception. The changes also improve code clarity and maintainability by centralizing configuration file logic.

Fixes #5 